### PR TITLE
Fix OK button preset

### DIFF
--- a/index.js
+++ b/index.js
@@ -557,7 +557,7 @@ instance.prototype.initPresets = function () {
 	
 	presets.push({
 		category: 'Keys',
-		label: 'Enter / OK',
+		label: 'Select / OK',
 		bank: {
 			style: 'png',
 				text: '',
@@ -571,7 +571,7 @@ instance.prototype.initPresets = function () {
 			action: 'key',
 			options:{
 				keytype: 'keypress',
-				keybutton: 'Enter'
+				keybutton: 'Select'
 			}
 		}]
 	});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "roku-tv",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"api_version": "1.0.0",
 	"keywords": [
 		"TV"


### PR DESCRIPTION
The OK button on a Roku remote actually maps to "Select", not "Enter". Before, this preset did nothing on my TV.